### PR TITLE
Feature/com rewrap make whole

### DIFF
--- a/pybilt/bilayer_analyzer/bilayer_analyzer.py
+++ b/pybilt/bilayer_analyzer/bilayer_analyzer.py
@@ -34,6 +34,7 @@ import com_frame as cf
 import leaflet as lf
 import vector_frame as vf
 import pybilt.lipid_grid.lipid_grid as lg
+#import pybilt.lipid_grid.lipid_grid_opt as lg
 import analysis_protocols as ap
 import plot_protocols as pp
 from pybilt.common.running_stats import RunningStats
@@ -306,7 +307,8 @@ class BilayerAnalyzer(object):
         self.rep_settings['com_frame'] = {'dump': False,
                                          'dump_path': "./",
                                          'name_dict': None,
-                                         'multi_bead': False}
+                                         'multi_bead': False,
+                                         'rewrap': False}
         #leaflets
         self.reps['leaflets'] = None
         self.rep_settings['leaflets'] = {'dump': False,
@@ -948,7 +950,8 @@ class BilayerAnalyzer(object):
                                              wrapcoord,
                                              name_dict =
                                         self.rep_settings['com_frame']['name_dict'],
-                                        multi_bead=self.rep_settings['com_frame']['multi_bead'])
+                                        multi_bead=self.rep_settings['com_frame']['multi_bead'],
+                                        rewrap=self.rep_settings['com_frame']['rewrap'])
                 if first_com:
                     self.reps['first_com_frame'] = self.reps['com_frame']
                     self._first_com = False
@@ -1017,7 +1020,7 @@ class BilayerAnalyzer(object):
             return
 
 
-    def unwrap_coordinates_up_to(frame_index):
+    def unwrap_coordinates_up_to(self, frame_index):
         # now we need to unwrap the coordinates
         natoms = self._mda_data.natoms
         oldcoord = np.zeros((natoms, 3))
@@ -1026,6 +1029,7 @@ class BilayerAnalyzer(object):
         #first_frame_coord = np.zeros((natoms, 3))
         index = self._mda_data.bilayer_sel.indices
         firstframe = self._first_frame
+        parallel = False
         #first_com = self._first_com
         #print("first com: ",first_com)
         #print("first frame: ", firstframe)
@@ -1037,7 +1041,7 @@ class BilayerAnalyzer(object):
         #print(self._current_frame)
         #frame = self.mda_data.mda_trajectory[self._current_frame]
         last_frame = frame_index
-        frame_step = self.settings['frame_range'][1]
+        frame_step = self.settings['frame_range'][2]
         if last_frame == -1:
             last_frame = len(self._mda_data.mda_trajectory)
         for frame in self._mda_data.mda_trajectory[0:last_frame+1:frame_step]:

--- a/pybilt/bilayer_analyzer/bilayer_analyzer.py
+++ b/pybilt/bilayer_analyzer/bilayer_analyzer.py
@@ -308,7 +308,8 @@ class BilayerAnalyzer(object):
                                          'dump_path': "./",
                                          'name_dict': None,
                                          'multi_bead': False,
-                                         'rewrap': False}
+                                         'rewrap': False,
+                                         'make_whole': False}
         #leaflets
         self.reps['leaflets'] = None
         self.rep_settings['leaflets'] = {'dump': False,

--- a/pybilt/bilayer_analyzer/com_frame.py
+++ b/pybilt/bilayer_analyzer/com_frame.py
@@ -106,7 +106,9 @@ class COMFrame(object):
     """
 
     # does not check that nlipids is an int
-    def __init__(self, mda_frame, mda_bilayer_selection, unwrap_coords, name_dict=None, multi_bead=False, rewrap=False):
+    def __init__(self, mda_frame, mda_bilayer_selection, unwrap_coords,
+                 name_dict=None, multi_bead=False, rewrap=False,
+                 make_whole=False):
         """ Frame initialization.
 
         Args:
@@ -131,6 +133,7 @@ class COMFrame(object):
         self._multi_bead = multi_bead
         self._name_dict = name_dict
         self._rewrapped = rewrap
+        self._make_whole = make_whole
         if (name_dict is not None) and multi_bead:
             self._build_multi_bead(mda_frame, mda_bilayer_selection,
                                    unwrap_coords, name_dict)
@@ -142,7 +145,8 @@ class COMFrame(object):
 
         return
 
-    def _build_single_bead(self, mda_frame, mda_bilayer_selection, unwrap_coords, name_dict=None):
+    def _build_single_bead(self, mda_frame, mda_bilayer_selection,
+                           unwrap_coords, name_dict=None):
         nlipids = len(mda_bilayer_selection.residues)
         # initialize all the LipidCOM objects
         for dummy_i in range(nlipids):
@@ -155,7 +159,7 @@ class COMFrame(object):
         r=0
         for res in mda_bilayer_selection.residues:
             #print(res," ",res.center_of_mass())
-            self.lipidcom[r].extract(res, name_dict=name_dict)
+            self.lipidcom[r].extract(res, name_dict=name_dict, make_whole=self._make_whole)
             #self.lipidcom[r].mass = res.total_mass()
             r+=1
         #now unwrapped coordinates
@@ -173,7 +177,7 @@ class COMFrame(object):
         self.mem_com = mem_com
         r=0
         for res in mda_bilayer_selection.residues:
-            self.lipidcom[r].extract(res, unwrap=True, name_dict=name_dict)
+            self.lipidcom[r].extract(res, unwrap=True, name_dict=name_dict, make_whole=self._make_whole)
             r+=1
         return
 
@@ -193,7 +197,7 @@ class COMFrame(object):
             for atom in name_dict[resname]:
                 name_dict_single = {resname:[atom]}
                 self.lipidcom.append(LipidCOM())
-                self.lipidcom[r].extract(res, name_dict=name_dict_single)
+                self.lipidcom[r].extract(res, name_dict=name_dict_single, make_whole=self._make_whole)
             #self.lipidcom[r].mass = res.total_mass()
                 r+=1
         #now unwrapped coordinates
@@ -217,7 +221,7 @@ class COMFrame(object):
             # initialize all the LipidCOM objects
             for atom in name_dict[resname]:
                 name_dict_single = {resname:[atom]}
-                self.lipidcom[r].extract(res, unwrap=True, name_dict=name_dict_single)
+                self.lipidcom[r].extract(res, unwrap=True, name_dict=name_dict_single, make_whole=self._make_whole)
             #self.lipidcom[r].mass = res.total_mass()
                 r+=1
         return


### PR DESCRIPTION
Added some more options for controlling the center of mass positions of lipids used in the com_frame object to account for coordinate wrapping/unwrapping. 

The rewrap functionality can be used when input coordinates are atomwise wrapped and are automatically unwrapped by the BilayerAnalyzer. The com_frame computes lipid centers of mass using the unwrapped coordinates and then tries to `rewrap' the unwrapped centers of mass back into the simulation box. This functionality works with obvious errors, but the output for own systems wasn't quite what I'd hoped for when check by visualization of centers of mass in 2d. Therefore, the make_whole functionality (below) seems to be a better option for achieving a similar effect of fixing lipid center of masses for breaks across periodic boundaries. 

The make_whole functionality uses the MDAnalysis.lib.mdamath.make_whole function to make lipids whole (if they split across periodic boundaries) before computing the center of mass. However, this functionality does require that the topology file has bonds (e.g. a psf file); e.g. make_whole will not work if a pdb or gro file given as the topology.  